### PR TITLE
Add optional parameter 'reason' in decline_challenge() method

### DIFF
--- a/berserk/__init__.py
+++ b/berserk/__init__.py
@@ -16,6 +16,7 @@ from .enums import Color  # noqa: F401
 from .enums import Room  # noqa: F401
 from .enums import Mode  # noqa: F401
 from .enums import Position  # noqa: F401
+from .enums import Reason  # noqa: F401
 from .formats import JSON  # noqa: F401
 from .formats import LIJSON  # noqa: F401
 from .formats import NDJSON  # noqa: F401

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -5,7 +5,8 @@ from deprecated import deprecated
 
 from .session import Requestor
 from .formats import JSON, LIJSON, PGN, NDJSON, TEXT
-from . import models, enums
+from .enums import Reason
+from . import models
 
 __all__ = [
     'Client',

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -5,7 +5,7 @@ from deprecated import deprecated
 
 from .session import Requestor
 from .formats import JSON, LIJSON, PGN, NDJSON, TEXT
-from . import models
+from . import models, enums
 
 __all__ = [
     'Client',
@@ -621,15 +621,19 @@ class Challenges(BaseClient):
         path = f'api/challenge/{challenge_id}/accept'
         return self._r.post(path)['ok']
 
-    def decline(self, challenge_id):
+    def decline(self, challenge_id, reason=Reason.GENERIC):
         """Decline an incoming challenge.
-
-        :param str challenge_id: id of the challenge to decline
+        :param str challenge_id: ID of a challenge
+        :param reason: reason for declining challenge
+        :type reason: :class:`~berserk.enums.Reason`
         :return: success indicator
         :rtype: bool
         """
         path = f'api/challenge/{challenge_id}/decline'
-        return self._r.post(path)['ok']
+        payload = {
+            'reason': reason
+        }
+        return self._r.post(path, json=payload)['ok']
 
 
 class Board(BaseClient):
@@ -861,15 +865,19 @@ class Bots(BaseClient):
         path = f'api/challenge/{challenge_id}/accept'
         return self._r.post(path)['ok']
 
-    def decline_challenge(self, challenge_id):
+    def decline_challenge(self, challenge_id, reason=Reason.GENERIC):
         """Decline an incoming challenge.
-
         :param str challenge_id: ID of a challenge
-        :return: success
+        :param reason: reason for declining challenge
+        :type reason: :class:`~berserk.enums.Reason`
+        :return: success indicator
         :rtype: bool
         """
         path = f'api/challenge/{challenge_id}/decline'
-        return self._r.post(path)['ok']
+        payload = {
+            'reason': reason
+        }
+        return self._r.post(path, json=payload)['ok']
 
 
 class Tournaments(FmtClient):

--- a/berserk/enums.py
+++ b/berserk/enums.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-__all__ = ['PerfType', 'Variant', 'Color', 'Room', 'Mode', 'Position']
+__all__ = ['PerfType', 'Variant', 'Color', 'Room', 'Mode', 'Position', 'Reason']
 
 
 class GameType:
@@ -40,6 +40,19 @@ class Room:
 class Mode:
     CASUAL = 'casual'
     RATED = 'rated'
+
+class Reason:
+    GENERIC = 'Generic'
+    LATER = "later"
+    TOOFAST = "tooFast"
+    TOOSLOW = "tooSlow"
+    TIMECONTROL = "timeControl"
+    RATED = "rated"
+    CASUAL = "casual"
+    STANDARD = "standard"
+    VARIANT = "variant"
+    NOBOT = "noBot"
+    ONLYBOT = "onlyBot"
 
 
 class Position:


### PR DESCRIPTION
As described in [the documentation](https://lichess.org/api#operation/challengeDecline) the **Decline a challenge** endpoint allows users to add a reason the challenge was declined.

This PR implements that option, and the parameter is optional so it's backwards compatible