### PR TITLE
Fix small grammar error in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Python client for the `Lichess API`_.
 Install
 ========
 
-Make sure berserk is uninstall before installing
+Make sure berserk is uninstalled before installing
 
 ``pip install berserk-downstream``
 


### PR DESCRIPTION
Noticed this while I was reading the README. The README doesn't seem to be from the upstream repo, so a fix here seems right.