### PR TITLE
support the literate keyword in game export client

### DIFF
--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -409,7 +409,8 @@ class Games(FmtClient):
                          max=None, vs=None, rated=None, perf_type=None,
                          color=None, analysed=None, moves=None,
                          pgn_in_json=None, tags=None, clocks=None, evals=None,
-                         opening=None, ongoing=None, finished=None, players=None, sort=None):
+                         opening=None, ongoing=None, finished=None, players=None,
+                         sort=None, literate=None):
         """Get games by player.
 
         :param str username: which player's games to return
@@ -459,6 +460,7 @@ class Games(FmtClient):
             'finished': finished,
             'players': players,
             'sort': sort,
+            'literate': literate,
         }
         fmt = PGN if self._use_pgn(as_pgn) else NDJSON
         yield from self._r.get(path, params=params, fmt=fmt, stream=True,


### PR DESCRIPTION
I noticed that the `literate` keyword in `export_by_player` was supported, but not implemented, so I added it.