### PR TITLE
Add support for the TV endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,10 @@ Most if not all of the API is available:
 
     client.messaging.send
 
+    client.tv.get_current_games
+    client.tv.stream_current_game
+    client.tv.get_best_ongoing
+
 
 Details for each function can be found in the `full documentation <https://berserk.readthedocs.io>`_.
 

--- a/berserk/clients.py
+++ b/berserk/clients.py
@@ -22,7 +22,8 @@ __all__ = [
     'Teams',
     'Tournaments',
     'Users',
-    'Messaging'
+    'Messaging',
+    'TV'
 ]
 
 # Base URL for the API
@@ -75,6 +76,9 @@ class Client(BaseClient):
     - :class:`tournaments <berserk.clients.Tournaments>` - getting and
       creating tournaments
     - :class:`users <berserk.clients.Users>` - getting information about users
+    - :class:`board <berserk.clients.Board>` - play games using a normal account
+    - :class:`messaging <berserk.clients.Messaging>` - private message other players
+    - :class:`tv <berserk.clients.TV>` - get information on tv channels and games
 
     :param session: request session, authenticated as needed
     :type session: :class:`requests.Session`
@@ -102,6 +106,7 @@ class Client(BaseClient):
         self.simuls = Simuls(session, base_url)
         self.studies = Studies(session, base_url)
         self.messaging = Messaging(session, base_url)
+        self.tv = TV(session, base_url)
 
 
 class Account(BaseClient):
@@ -521,6 +526,7 @@ class Games(FmtClient):
         params = {'nb': count}
         return self._r.get(path, params=params)['nowPlaying']
 
+    @deprecated(version='0.12.0', reason='use TV.get_current_games')
     def get_tv_channels(self):
         """Get basic information about the best games being played.
 
@@ -1493,3 +1499,51 @@ class Messaging(BaseClient):
             'text': text
         }
         self._r.post(path, data=payload)
+
+
+class TV(FmtClient):
+    """Client for TV related endpoints."""
+
+    def get_current_games(self):
+        """Get basic information about the current TV games being played
+
+        :return: best ongoing games in each speed and variant
+        :rtype: dict
+        """
+        path = 'api/tv/channels'
+        return self._r.get(path)
+
+    def stream_current_game(self):
+        """Streams the current TV game
+
+        :return: positions and moves of the current TV game
+        :rtype: dict
+        """
+        path = 'api/tv/feed'
+        yield from self._r.get(path, stream=True)
+
+    def get_best_ongoing(self, channel, as_pgn=None, count=None, moves=None,
+                         pgn_in_json=None, tags=None, clocks=None, opening=None):
+        """Get a list of ongoing games for a given TV channel in PGN or NDJSON.
+
+        :param str channel: the name of the TV channel in camel case
+        :param bool as_pgn: whether to return the game in PGN format
+        :param int count: the number of games to fetch [1..30]
+        :param bool moves: whether to include the PGN moves
+        :param bool pgn_in_json: include the full PGN within JSON response
+        :param bool tags: whether to include the PGN tags
+        :param bool clocks: whether to include clock comments in the PGN moves
+        :param bool opening: whether to include the opening name
+        :return: the ongoing games of the given TV channel in PGN or NDJSON
+        """
+        path = f'api/tv/{channel}'
+        params = {
+            'nb': count,
+            'moves': moves,
+            'pgnInJson': pgn_in_json,
+            'tags': tags,
+            'clocks': clocks,
+            'opening': opening,
+        }
+        fmt = PGN if self._use_pgn(as_pgn) else NDJSON
+        return self._r.get(path, params=params, fmt=fmt, converter=models.TV.convert)

--- a/berserk/models.py
+++ b/berserk/models.py
@@ -88,3 +88,8 @@ class RatingHistory(Model):
 
 class PuzzleActivity(Model):
     date = utils.datetime_from_millis
+
+
+class TV(Model):
+    createdAt = utils.datetime_from_millis
+    lastMoveAt = utils.datetime_from_millis


### PR DESCRIPTION
Brings in support for the [TV endpoint](https://lichess.org/api#tag/TV).

Deprecated `Games.get_tv_channels` as this belongs under the `TV` endpoint (replaced with `TV.get_current_games`).