### PR TITLE
tests: add python3.11 target in tox.ini file

### DIFF
--- a/requirements_dev_py311.txt
+++ b/requirements_dev_py311.txt
@@ -1,0 +1,17 @@
+pip==19.3.1
+bumpversion==0.5.3
+wheel==0.33.6
+watchdog==0.9.0
+flake8==3.7.9
+tox==3.14.3
+coverage==5.0.1
+Sphinx==2.3.1
+twine==3.1.1
+
+pytest
+pytest-runner
+
+sphinx-rtd-theme==0.4.3
+
+codecov==2.0.22
+pytest-cov==2.8.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py37, flake8
+envlist = py37, py311, flake8
 skip_missing_interpreters = true
 
 [travis]
 python =
     3.7: py37
+    3.11: py311
 
 [testenv:flake8]
 basepython = python
@@ -16,7 +17,8 @@ setenv =
     PYTHONPATH = {toxinidir}
 passenv = LICHESS_TOKEN CI TRAVIS TRAVIS_*
 deps =
-    -r{toxinidir}/requirements_dev.txt
+    py37: -r{toxinidir}/requirements_dev.txt
+    py311: -r{toxinidir}/requirements_dev_py311.txt
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following line:
 ;     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Hello,
it would be great if berserk's tox.ini file supported the newly-released python3.11.
Here is a PR for adding that support.
For now all the requirements from requirements_dev.txt have been copied to a dedicated file, without the version limitations that immediately break the tests. I guess some other version restrictions are not recessary but they don't break the tests with python3.11.